### PR TITLE
Add DCA helper and tests

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -4,138 +4,183 @@ import numpy as np
 import yfinance as yf
 import plotly.graph_objects as go
 
-st.set_page_config(page_title="DCA Calculator", page_icon="💰")
 
-# Title
-st.title("Dollar Cost Averaging (DCA) Calculator")
+def calculate_dca(filtered_data: pd.DataFrame, regular_contribution: float, initial_investment: float):
+    """Return a DataFrame containing the DCA log and totals.
 
-# Sidebar Inputs
-st.sidebar.header("Investment Parameters")
-ticker = st.sidebar.text_input("Stock Ticker (e.g., AAPL, TSLA)", value="AAPL")
-initial_investment = st.sidebar.number_input("Initial Investment ($)", min_value=0.0, value=0.0)
-regular_contribution = st.sidebar.number_input("Regular Contribution ($)", min_value=0.0, value=100.0)
-frequency = st.sidebar.selectbox("Contribution Frequency", ["Daily", "Weekly", "Monthly"])
+    Parameters
+    ----------
+    filtered_data : pd.DataFrame
+        DataFrame indexed by date with a ``Close`` column.
+    regular_contribution : float
+        The contribution added at each interval.
+    initial_investment : float
+        Extra amount invested on the first interval.
 
-# Date Picker for Backtesting Range
-st.sidebar.header("Backtesting Date Range")
-start_date = st.sidebar.date_input("Start Date", value=pd.to_datetime("2018-01-01"))
-end_date = st.sidebar.date_input("End Date", value=pd.to_datetime("today"))
+    Returns
+    -------
+    Tuple[pd.DataFrame, float, float]
+        The DCA log, total shares and total amount invested.
+    """
 
-if start_date >= end_date:
-    st.error("Start date must be earlier than end date. Please adjust the dates.")
-    st.stop()
+    total_invested = 0.0
+    total_shares = 0.0
+    dca_log = []
 
-# Fetch Stock Data within Selected Date Range
-try:
-    stock_data = yf.Ticker(ticker).history(start=start_date, end=end_date)
-    stock_data.reset_index(inplace=True)
-    stock_data = stock_data[["Date", "Close"]]
-    stock_data["Date"] = pd.to_datetime(stock_data["Date"])
+    for i, (date, row) in enumerate(filtered_data.iterrows()):
+        price = row["Close"]
+        contribution = regular_contribution
+        if i == 0:
+            contribution += initial_investment
+        total_shares += contribution / price
+        total_invested += contribution
+        dca_log.append(
+            {
+                "Date": date,
+                "Price": price,
+                "Total Shares": total_shares,
+                "Total Investment": total_invested,
+                "Portfolio Value": total_shares * price,
+            }
+        )
 
-    # Remove timezone information from the Date column
-    stock_data["Date"] = stock_data["Date"].dt.tz_localize(None)
+    return pd.DataFrame(dca_log), total_shares, total_invested
 
-    if stock_data.empty:
-        st.error("No data available for the selected date range. Please choose a different range.")
+
+def main():
+
+    st.set_page_config(page_title="DCA Calculator", page_icon="💰")
+
+    # Title
+    st.title("Dollar Cost Averaging (DCA) Calculator")
+
+    # Sidebar Inputs
+    st.sidebar.header("Investment Parameters")
+    ticker = st.sidebar.text_input("Stock Ticker (e.g., AAPL, TSLA)", value="AAPL")
+    initial_investment = st.sidebar.number_input("Initial Investment ($)", min_value=0.0, value=0.0)
+    regular_contribution = st.sidebar.number_input("Regular Contribution ($)", min_value=0.0, value=100.0)
+    frequency = st.sidebar.selectbox("Contribution Frequency", ["Daily", "Weekly", "Monthly"])
+
+    # Date Picker for Backtesting Range
+    st.sidebar.header("Backtesting Date Range")
+    start_date = st.sidebar.date_input("Start Date", value=pd.to_datetime("2018-01-01"))
+    end_date = st.sidebar.date_input("End Date", value=pd.to_datetime("today"))
+
+    if start_date >= end_date:
+        st.error("Start date must be earlier than end date. Please adjust the dates.")
         st.stop()
 
-    st.sidebar.success(f"Data fetched for {ticker}!")
-except Exception as e:
-    st.sidebar.error("Error fetching stock data. Please check the ticker symbol.")
-    st.stop()
+    # Fetch Stock Data within Selected Date Range
+    try:
+        stock_data = yf.Ticker(ticker).history(start=start_date, end=end_date)
+        stock_data.reset_index(inplace=True)
+        stock_data = stock_data[["Date", "Close"]]
+        stock_data["Date"] = pd.to_datetime(stock_data["Date"])
 
-# Filter Data Based on Selected Dates (Redundant but Ensures Safety)
-filtered_data = stock_data[(stock_data["Date"] >= pd.Timestamp(start_date)) & (stock_data["Date"] <= pd.Timestamp(end_date))]
+        # Remove timezone information from the Date column
+        stock_data["Date"] = stock_data["Date"].dt.tz_localize(None)
 
-# Adjust frequency
-filtered_data.set_index("Date", inplace=True)
-if frequency == "Weekly":
-    filtered_data = filtered_data.resample("W").mean()
-elif frequency == "Monthly":
-    filtered_data = filtered_data.resample("M").mean()
+        if stock_data.empty:
+            st.error("No data available for the selected date range. Please choose a different range.")
+            st.stop()
 
-# Perform DCA Calculation
-total_invested = 0
-total_shares = 0
-dca_log = []
+        st.sidebar.success(f"Data fetched for {ticker}!")
+    except Exception as e:
+        st.sidebar.error("Error fetching stock data. Please check the ticker symbol.")
+        st.stop()
 
-for i, (date, row) in enumerate(filtered_data.iterrows()):
-    price = row['Close']
-    contribution = regular_contribution
-    if i == 0:
-        contribution += initial_investment
-    total_shares += contribution / price
-    total_invested += contribution
-    dca_log.append({
-        "Date": date,
-        "Price": price,
-        "Total Shares": total_shares,
-        "Total Investment": total_invested,
-        "Portfolio Value": total_shares * price})
+    # Filter Data Based on Selected Dates (Redundant but Ensures Safety)
+    filtered_data = stock_data[(stock_data["Date"] >= pd.Timestamp(start_date)) & (stock_data["Date"] <= pd.Timestamp(end_date))]
 
-dca_df = pd.DataFrame(dca_log)
+    # Adjust frequency
+    filtered_data.set_index("Date", inplace=True)
+    if frequency == "Weekly":
+        filtered_data = filtered_data.resample("W").mean()
+    elif frequency == "Monthly":
+        filtered_data = filtered_data.resample("M").mean()
 
-contributions = dca_df["Total Investment"]
-portfolio_value = dca_df['Portfolio Value']
+    dca_df, total_shares, total_invested = calculate_dca(
+        filtered_data,
+        regular_contribution=regular_contribution,
+        initial_investment=initial_investment,
+    )
+
+    contributions = dca_df["Total Investment"]
+    portfolio_value = dca_df["Portfolio Value"]
+
+    # Results
+    st.subheader("Results")
+    final_value = portfolio_value.iloc[-1]
+    net_gain_loss = final_value - total_invested
+
+    st.write(f"**Total Invested:** ${total_invested:.2f}")
+    st.write(f"**Final Portfolio Value:** ${final_value:.2f}")
+    st.write(f"**Net Gain/Loss:** ${net_gain_loss:.2f} ({net_gain_loss / total_invested * 100:.2f}%)")
+
+    # Visualizations
+    st.subheader("Visualizations")
+
+    # Asset Price Over Time
+    price_fig = go.Figure()
+    price_fig.add_trace(
+        go.Scatter(x=filtered_data.index, y=filtered_data["Close"], mode="lines", name="Asset Price")
+    )
+    price_fig.update_layout(title="Asset Price Over Time", xaxis_title="Date", yaxis_title="Price ($)")
+    st.plotly_chart(price_fig)
+
+    # Portfolio Value vs Total Invested
+    portfolio_fig = go.Figure()
+    portfolio_fig.add_trace(
+        go.Scatter(x=filtered_data.index, y=portfolio_value, mode="lines", name="Portfolio Value")
+    )
+    portfolio_fig.add_trace(
+        go.Scatter(
+            x=filtered_data.index,
+            y=contributions,
+            mode="lines",
+            name="Total Invested",
+            line=dict(dash="dash"),
+        )
+    )
+    portfolio_fig.update_layout(title="Portfolio Value vs Total Invested", xaxis_title="Date", yaxis_title="Value ($)")
+    st.plotly_chart(portfolio_fig)
+
+    # Stacked Bar Chart
+    fig = go.Figure()
+
+    # Add Total Invested
+    fig.add_trace(
+        go.Bar(
+            x=dca_df["Date"],
+            y=dca_df["Total Investment"],
+            name="Total Invested",
+            marker_color="blue",
+        )
+    )
+
+    # Add Profit/Loss
+    fig.add_trace(
+        go.Bar(
+            x=dca_df["Date"],
+            y=dca_df["Portfolio Value"] - dca_df["Total Investment"],
+            name="Profit/Loss",
+            marker_color="green",
+        )
+    )
+
+    # Update layout for better appearance
+    fig.update_layout(
+        title="DCA Results: Total Invested and Profit/Loss",
+        xaxis_title="Years",
+        yaxis_title="Amount ($)",
+        barmode="stack",  # Stacked bars
+        legend_title="Legend",
+    )
+
+    # Display in Streamlit
+    st.plotly_chart(fig)
 
 
-# Results
-st.subheader("Results")
-final_value = portfolio_value.iloc[-1]
-net_gain_loss = final_value - total_invested
-
-st.write(f"**Total Invested:** ${total_invested:.2f}")
-st.write(f"**Final Portfolio Value:** ${final_value:.2f}")
-st.write(f"**Net Gain/Loss:** ${net_gain_loss:.2f} ({net_gain_loss / total_invested * 100:.2f}%)")
-
-# Visualizations
-st.subheader("Visualizations")
-
-# Asset Price Over Time
-price_fig = go.Figure()
-price_fig.add_trace(go.Scatter(x=filtered_data.index, y=filtered_data["Close"], mode="lines", name="Asset Price"))
-price_fig.update_layout(title="Asset Price Over Time", xaxis_title="Date", yaxis_title="Price ($)")
-st.plotly_chart(price_fig)
-
-# Portfolio Value vs Total Invested
-portfolio_fig = go.Figure()
-portfolio_fig.add_trace(go.Scatter(x=filtered_data.index, y=portfolio_value, mode="lines", name="Portfolio Value"))
-portfolio_fig.add_trace(go.Scatter(x=filtered_data.index, y=contributions, mode="lines", name="Total Invested", line=dict(dash="dash")))
-portfolio_fig.update_layout(title="Portfolio Value vs Total Invested", xaxis_title="Date", yaxis_title="Value ($)")
-st.plotly_chart(portfolio_fig)
-
-
-# Stacked Bar Chart
-
-
-# Create a Stacked Bar Chart
-fig = go.Figure()
-
-# Add Total Invested
-fig.add_trace(go.Bar(
-    x=dca_df["Date"],
-    y=dca_df["Total Investment"],
-    name="Total Invested",
-    marker_color="blue"
-))
-
-# Add Profit/Loss
-fig.add_trace(go.Bar(
-    x=dca_df["Date"],
-    y=dca_df["Portfolio Value"] - dca_df["Total Investment"],
-    name="Profit/Loss",
-    marker_color="green"
-))
-
-# Update layout for better appearance
-fig.update_layout(
-    title="DCA Results: Total Invested and Profit/Loss",
-    xaxis_title="Years",
-    yaxis_title="Amount ($)",
-    barmode="stack",  # Stacked bars
-    legend_title="Legend"
-)
-
-# Display in Streamlit
-st.plotly_chart(fig)
+if __name__ == "__main__":
+    main()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 matplotlib
 plotly
 yfinance
+pytest

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -1,0 +1,24 @@
+import pytest
+import sys
+import types
+import pandas as pd
+
+# Create minimal dummy modules to satisfy imports in calculator
+sys.modules.setdefault('streamlit', types.ModuleType('streamlit'))
+sys.modules.setdefault('yfinance', types.ModuleType('yfinance'))
+plotly = types.ModuleType('plotly')
+plotly.graph_objects = types.ModuleType('graph_objects')
+sys.modules.setdefault('plotly', plotly)
+sys.modules.setdefault('plotly.graph_objects', plotly.graph_objects)
+
+from calculator import calculate_dca
+
+
+def test_calculate_dca_basic():
+    prices = pd.DataFrame({"Close": [10.0, 20.0, 40.0]}, index=pd.date_range('2020-01-01', periods=3))
+    dca_df, total_shares, total_invested = calculate_dca(prices, regular_contribution=100, initial_investment=50)
+
+    assert total_shares == pytest.approx(22.5)
+    assert total_invested == pytest.approx(350)
+    assert dca_df["Total Shares"].iloc[-1] == pytest.approx(22.5)
+    assert dca_df["Total Investment"].iloc[-1] == pytest.approx(350)


### PR DESCRIPTION
## Summary
- refactor DCA logic into new `calculate_dca` helper inside `calculator.py`
- wrap Streamlit app in `main()` and guard execution
- create unit test for the helper
- include pytest in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68623912828c832a9fcbcbb1a07e26b8